### PR TITLE
Mx3 deb9 docker

### DIFF
--- a/demo/master_qt4/Dockerfile
+++ b/demo/master_qt4/Dockerfile
@@ -1,0 +1,20 @@
+FROM mx3_deb9_qt4
+
+# For deploying the application
+# We should better tag a version
+RUN git clone git://github.com/mxcube/mxcube /MXCuBE/mxcube
+WORKDIR /MXCuBE/mxcube
+RUN git submodule init
+RUN git submodule update
+WORKDIR /MXCuBE/mxcube/HardwareObjects
+RUN git checkout master
+WORKDIR /MXCuBE/mxcube/HardwareRepository
+RUN git checkout master
+WORKDIR /MXCuBE/mxcube/Blissframework
+RUN git checkout master
+WORKDIR /MXCuBE/mxcube/bin
+ENV USER unknown
+ENV INSTITUTION unknown
+ENV MXCUBE_ROOT /MXCuBE/mxcube
+
+ENTRYPOINT ["/MXCuBE/mxcube/bin/mxcube2"]

--- a/demo/master_qt4/README.md
+++ b/demo/master_qt4/README.md
@@ -1,0 +1,20 @@
+# Docker file for MXCuBE2 demo: Qt4/master
+
+This Docker image is intended to deploy an example mxcube2 application in a docker container based on debian9.
+
+### Before starting
+
+You first need to build the base image `mx3_deb9_qt4` provided in this repository.
+
+### Building the docker image
+
+    docker build -t mx3_deb9_qt4_master .
+
+### Running the demo application
+Execute the following commands to start the container:
+
+    xhost +local:
+
+    docker run -d -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix mx3_deb9_qt4_master
+
+or run the `start_mxcube2` script provided.

--- a/demo/master_qt4/start_mxcube2
+++ b/demo/master_qt4/start_mxcube2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+CONTAINER=mx3_deb9_qt4_master
+
+xhost +local:
+docker run -d -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix $CONTAINER

--- a/dev/Debian9_qt4/Dockerfile
+++ b/dev/Debian9_qt4/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:stretch
+RUN apt-get update
+RUN apt-get install -y git vim
+RUN apt-get install -y python-qt4
+RUN apt-get install -y python-gevent
+RUN apt-get install -y python-louie
+RUN apt-get install -y python-jsonpickle
+RUN apt-get install -y python-numpy
+RUN apt-get install -y python-scipy
+RUN apt-get install -y python-matplotlib
+RUN apt-get install -y python-suds pymca
+RUN apt-get install -y python-yaml
+RUN apt-get install -y python-pydispatch
+
+RUN mkdir -p /MXCuBE/mxcube
+WORKDIR /MXCuBE/mxcube
+
+
+# For deploying the application
+#RUN git clone git://github.com/mxcube/mxcube /MXCuBE/mxcube
+#WORKDIR /MXCuBE/mxcube
+#RUN git submodule init
+#RUN git submodule update
+#WORKDIR /MXCuBE/mxcube/HardwareObjects
+#RUN git checkout master
+#WORKDIR /MXCuBE/mxcube/HardwareRepository
+#RUN git checkout master
+#WORKDIR /MXCuBE/mxcube/Blissframework
+#RUN git checkout master
+#WORKDIR /MXCuBE/mxcube/bin
+#ENV USER unknown
+#ENV INSTITUTION unknown
+#ENV MXCUBE_ROOT /MXCuBE/mxcube
+
+# Run after starting the container
+#ENTRYPOINT ["/MXCuBE/mxcube/bin/mxcube2"]

--- a/dev/Debian9_qt4/README.md
+++ b/dev/Debian9_qt4/README.md
@@ -1,0 +1,23 @@
+# mx3docker
+Docker file + startup script for MXCuBE 2 + qt4 development version
+
+The docker mounts your local copy of the MXCuBE repository through a shared mounted directory.
+
+## Building the docker image
+
+    docker build -t mx3_deb9_qt4 /path/to/mx3docker/dev/Debian9_qt4
+
+## Before starting:
+
+Set environment variable, e.g. (in ~/.bashrc for bash):
+
+    export MXCUBE2_ROOT=/path/to/dir/containing/mxcube/repository
+
+
+## Running the container
+Execute the `start_mxcube2` script to run the right docker command line with required options:
+
+    ./start_mxcube2
+
+This will prompt you to the the working directory inside the clean docker container.
+

--- a/dev/Debian9_qt4/start_mxcube2
+++ b/dev/Debian9_qt4/start_mxcube2
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+CONTAINER=mx3_deb9_qt4
+
+xhost +local:
+exec docker run -it -h=$CONTAINER -v $MXCUBE2_ROOT:/MXCuBE/mxcube -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix $CONTAINER


### PR DESCRIPTION
This PR provides:
* A Dockerfile to cretae a base image for mxcube2, based on debian9 and qt4 (+ all mxcube requirements)
* A Dockerfile to create an image for deploying the demo version of the mxcube2 application based on the previous base image.