### PR TITLE
Fix missing enum dependency

### DIFF
--- a/dev/Debian9_qt4/Dockerfile
+++ b/dev/Debian9_qt4/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get install -y python-matplotlib
 RUN apt-get install -y python-suds pymca
 RUN apt-get install -y python-yaml
 RUN apt-get install -y python-pydispatch
+RUN apt-get install -y python-enum34
 
 RUN mkdir -p /MXCuBE/mxcube
 WORKDIR /MXCuBE/mxcube


### PR DESCRIPTION
The enum34 library is now a dependency for mxcube2.

Add the installation of this dependency to the Dockerfile for the Debian9_qt4 image.