### PR TITLE
Adapt demo-qt4 to new repository structure

### DIFF
--- a/demo/master_qt4/Dockerfile
+++ b/demo/master_qt4/Dockerfile
@@ -1,20 +1,11 @@
 FROM mx3_deb9_qt4
 
-# For deploying the application
-# We should better tag a version
-RUN git clone git://github.com/mxcube/mxcube /MXCuBE/mxcube
 WORKDIR /MXCuBE/mxcube
+RUN git clone git://github.com/mxcube/mxcube /MXCuBE/mxcube -b master
 RUN git submodule init
 RUN git submodule update
-WORKDIR /MXCuBE/mxcube/HardwareObjects
-RUN git checkout master
-WORKDIR /MXCuBE/mxcube/HardwareRepository
-RUN git checkout master
-WORKDIR /MXCuBE/mxcube/Blissframework
-RUN git checkout master
 WORKDIR /MXCuBE/mxcube/bin
-ENV USER unknown
-ENV INSTITUTION unknown
-ENV MXCUBE_ROOT /MXCuBE/mxcube
+ENV USER unknown-user
+ENV HARDWARE_REPOSITORY_SERVER /MXCuBE/mxcube/ExampleFiles/HardwareRepository.xml
 
-ENTRYPOINT ["/MXCuBE/mxcube/bin/mxcube2"]
+ENTRYPOINT ["/MXCuBE/mxcube/bin/mxcube"]

--- a/demo/master_qt4/README.md
+++ b/demo/master_qt4/README.md
@@ -8,13 +8,13 @@ You first need to build the base image `mx3_deb9_qt4` provided in this repositor
 
 ### Building the docker image
 
-    docker build -t mx3_deb9_qt4_master .
+    docker build -t mx3_deb9_qt4_master_demo /path/to/mx3docker/demo/master_qt4
 
 ### Running the demo application
 Execute the following commands to start the container:
 
     xhost +local:
 
-    docker run -d -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix mx3_deb9_qt4_master
+    docker run -d -e HARDWARE_REPOSITORY_SERVER=/MXCuBE/mxcube/ExampleFiles/HardwareObjects.xml -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix mx3_deb9_qt4_master_demo
 
 or run the `start_mxcube2` script provided.

--- a/demo/master_qt4/start_mxcube2
+++ b/demo/master_qt4/start_mxcube2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-CONTAINER=mx3_deb9_qt4_master
+CONTAINER=mx3_deb9_qt4_master_demo
 
 xhost +local:
-docker run -d -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix $CONTAINER
+docker run -d -e HARDWARE_REPOSITORY_SERVER=/MXCuBE/mxcube/ExampleFiles/HardwareObjects.xml -e DISPLAY=$DISPLAY -e QT_X11_NO_MITSHM=1 -v /tmp/.X11-unix:/tmp/.X11-unix mx3_deb9_qt4_master_demo


### PR DESCRIPTION
Adapt to new repository structure and use the bin/mxcube
as default launcher for the example application.

Modifies the checkout of the mxcube repository to the local
container.
Modifies the Dockerfile and script to run the mxcube using
the bin/mxcube launcher as ENTRYPOINT.