### PR TITLE
Build for python3

### DIFF
--- a/dev/mxcube3/mxcube3-docker-debian9-dev/Dockerfile
+++ b/dev/mxcube3/mxcube3-docker-debian9-dev/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile to run MXCuBE web server
 ##############################################################################
 
-FROM debian:9
+FROM debian:10
 MAINTAINER Marcus Oscarsson <marcus.oscarsson@esrf.fr>
 
 ENV TERM linux

--- a/dev/mxcube3/mxcube3-docker-debian9-dev/Dockerfile
+++ b/dev/mxcube3/mxcube3-docker-debian9-dev/Dockerfile
@@ -11,8 +11,8 @@ ENV USER root
 # Install system pacakges
 
 RUN apt-get update && apt-get -y upgrade && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --fix-missing -y mate-desktop-environment-core && \       
-    apt-get install -y apt-utils curl git sudo build-essential wget python \
+    DEBIAN_FRONTEND=noninteractive apt-get install --fix-missing -y mate-desktop-environment-core && \
+    apt-get install -y apt-utils curl git sudo build-essential wget \
     tightvncserver emacs xemacs21 vim procps
 
 RUN mkdir /root/.vnc && echo "mxcube" | vncpasswd -f > /root/.vnc/passwd && chmod 600 /root/.vnc/passwd

--- a/dev/mxcube3/mxcube3-docker-debian9-dev/debian-install.sh
+++ b/dev/mxcube3/mxcube3-docker-debian9-dev/debian-install.sh
@@ -72,14 +72,9 @@ install_node() {
   command npm install
 }
 
-install_pngquant() {
-  command cd /opt/mxcube3
-}
-
 mxcube_download
 install_debian_deps
 install_python_deps
-install_pngquant
 install_node
 
 } # this ensures the entire script is downloaded #

--- a/dev/mxcube3/mxcube3-docker-debian9-dev/debian-install.sh
+++ b/dev/mxcube3/mxcube3-docker-debian9-dev/debian-install.sh
@@ -38,7 +38,7 @@ install_debian_deps() {
   command apt-get -y install libblas-dev liblapack-dev libatlas-base-dev gfortran
 
   # python-ldap
-  command apt-get -y install libsasl2-dev python-pip python python-dev libldap2-dev libssl-dev
+  command apt-get -y install libsasl2-dev python3-pip python3 python3-dev libldap2-dev libssl-dev
 
   # redis
   command apt-get -y install redis-server
@@ -50,17 +50,17 @@ install_debian_deps() {
   command apt-get -y install ffmpeg
 
   #pillow
-  command apt-get -y install libxml2-dev libxslt-dev libtiff-dev libjpeg-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python-tk
+  command apt-get -y install libxml2-dev libxslt-dev libtiff-dev libjpeg-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python3-tk
 
   # npm package imagemin
   command apt-get -y install nodejs nodejs-legacy build-essential nasm libpng12-dev libpng-dev libpng++-dev libpng-tools libpng16-16 zlibc pkg-config
   command apt-get -y install libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential librsvg2-dev
-  
+
 }
 
 install_python_deps() {
-  command pip2 install numpy
-  command pip2 install -r requirements.txt
+  command pip3 install numpy
+  command pip3 install -r requirements-py3.txt
 }
 
 install_node() {

--- a/dev/mxcube3/mxcube3-docker-debian9-dev/debian-install.sh
+++ b/dev/mxcube3/mxcube3-docker-debian9-dev/debian-install.sh
@@ -49,9 +49,6 @@ install_debian_deps() {
   #ffmpeg
   command apt-get -y install ffmpeg
 
-  #pillow
-  command apt-get -y install libxml2-dev libxslt-dev libtiff-dev libjpeg-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.5-dev tk8.5-dev python3-tk
-
   # npm package imagemin
   command apt-get -y install nodejs nodejs-legacy build-essential nasm libpng12-dev libpng-dev libpng++-dev libpng-tools libpng16-16 zlibc pkg-config
   command apt-get -y install libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential librsvg2-dev

--- a/dev/mxcube3/mxcube3-docker-debian9-dev/docker-entrypoint.sh
+++ b/dev/mxcube3/mxcube3-docker-debian9-dev/docker-entrypoint.sh
@@ -9,6 +9,6 @@ source "$NVM_DIR/bash_completion"
 vncserver :1 -geometry 1680x1050 -depth 24 &
 
 redis-server&
-python mxcube3-server -r test/HardwareObjectsMockup.xml --log-file mxcube.log&
+python3 mxcube3-server -r test/HardwareObjectsMockup.xml --log-file mxcube.log&
 npm start&
 wait


### PR DESCRIPTION
Hi,

This PR builds the container for python3 instead of python2.
The base Docker image is changed to debian:10, in which python 3.7 is the default (on debian:9, the default is 3.5).

Also, some unused dependencies and methods are cleaned up.

Thanks,
Laís